### PR TITLE
Fix checking for Android platform

### DIFF
--- a/Couchbase Lite/js/index.js
+++ b/Couchbase Lite/js/index.js
@@ -589,7 +589,7 @@ function setupConfig(done) {
         console.log("getURL: " + JSON.stringify([err, url]))
         if (err) {return done(err)}
 
-        if (!/Apple/.test(navigator.userAgent)) {
+        if (device.platform.toLowerCase() === "android") {
             // this helps on Android < 4.4
             // otherwise basic auth doesn't work
             var xmlHttp = new XMLHttpRequest()
@@ -655,7 +655,6 @@ function setupConfig(done) {
 
     function setupDb(db, cb) {
         db.get(function(err, res, body){
-            console.log(JSON.stringify(["before create db put", err, res, body]))
             db.put(function(err, res, body){
                 db.get(cb)
             })


### PR DESCRIPTION
Also removed problematic console.log
Fixes: http://teampulse.telerik.com/view#/12142
## Bug;s description:

Using the Couchbase app from here http://plugins.telerik.com/plugin/couchbase-lite I was unable to operate with it after deployed on Android. Only white screen is represented.

Tested with 'Build and deploy'  and QR deployment.

It is reproducible on most of the devices - Nexus 5 OS 4.4.3, Nexus 4 OS 4.3, Samsung 4.1.2
## The strange is that after I deleted the plugin and manually added it the app started to work.

ping @EddyVerbruggen @mbektchiev
